### PR TITLE
feat: Added JSDs GenAI CasaOS AppStore

### DIFF
--- a/content/3rd-party-app-stores/list.md
+++ b/content/3rd-party-app-stores/list.md
@@ -92,3 +92,13 @@ Source link:
 https://github.com/arch3rPro/Pentest-Docker/archive/refs/heads/master.zip
 ```
 [GitHub Repo](https://github.com/arch3rPro/Pentest-Docker)
+
+## 9. JSDs Generative AI Workbench CasaOS AppStore
+
+The Foundry Workbench is a CasaOS third-party Appstore and offers a collection of apps and tools, ready-to-use solution for fellow digital artisans and studios who want to concept, design, develop, create and publish beautiful and functional digital projects and services. Don't let the ZimaOS name within the repository confuse you, the AI Workbench works perfectly on CasaOS aslong as you have the GPUs to support it!
+Source link:
+
+``` bash
+https://github.com/justserdar/ZimaOS-AppStore/releases/tag/latest-v0.0.4
+```
+[GitHub Repo](https://github.com/justserdar/ZimaOS-AppStore)


### PR DESCRIPTION
I would like to provide my [CasaOS/ZimaOS(oriented) AppStore](https://workbench.justserdar.dev) targeting Generative AI, VFX, Digital audio-visual content generation and production Apps. 

Thinking they earn a spot in the list because they highlight a big strength of f.e the ZimaCube Pro's GPU and or any CasaOS system that has a RTX GPU for that matter. A lot of studios and production houses can benefit greatly since many of them use custom tooling and hardware for their ultra-customized hardware needs.

**TLDR**: I need to make some changes before the App Store is ready, so I started this draft PR just too give a heads up.

CasaOS/ZimaOS is already reshaping how I move my business forward end of 2024.
I could use some help double checking my images for errors, I've commited a bunch of changes over my images so they include the descriptors for environment, volume, port variables for the store. Some need thumbails and screenshots (also WIP). 

The Blender image is a copy of WisdomSky's second store, casaos/linuxserver.
The Coolify image is a WIP based on Dragonfire1119's Coolify image from the Big Bear App Store, the necessary changes for ZimaOS will be PR'd into his OG repo once we have a specific fix for ZimaOS (stay tuned).